### PR TITLE
Postman converter fix

### DIFF
--- a/src/Nightingale.Converters/Nightingale.Converters.csproj
+++ b/src/Nightingale.Converters/Nightingale.Converters.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <PackageReference Include="JeniusApps.Insomnia.NET" Version="0.0.3-preview" />
     <PackageReference Include="JeniusApps.Postman.NET" Version="0.2.4-preview" />
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.OpenApi" Version="1.2.3" />
     <PackageReference Include="MimeMapping" Version="1.0.1.30" />
   </ItemGroup>

--- a/src/Nightingale.Converters/Postman/PostmanConverter.cs
+++ b/src/Nightingale.Converters/Postman/PostmanConverter.cs
@@ -68,18 +68,18 @@ namespace Nightingale.Converters.Postman
                 }
                 else if (item.Items != null && item.Items.Length > 0)
                 {
-                    Item nightingaleSubCollection = new Item
+                    Item ngSubCollection = new Item
                     {
                         Type = ItemType.Collection,
                         Children = new List<Item>(),
                         Name = item.Name
                     };
-                    IList<Item> nightingaleChildren = ConvertItems(item.Items);
-                    if (nightingaleChildren != null)
+                    IList<Item> ngChildren = ConvertItems(item.Items);
+                    if (ngChildren != null)
                     {
-                        nightingaleSubCollection.Children.AddRange(nightingaleChildren);
+                        ngSubCollection.Children.AddRange(ngChildren);
                     }
-                    list.Add(nightingaleSubCollection);
+                    list.Add(ngSubCollection);
                 }
             }
 

--- a/src/Nightingale.Converters/Postman/PostmanConverter.cs
+++ b/src/Nightingale.Converters/Postman/PostmanConverter.cs
@@ -263,7 +263,7 @@ namespace Nightingale.Converters.Postman
                         Enabled = !query.Disabled,
                         Key = query.Key,
                         Value = query.Value,
-                        Type = ParamType.Header
+                        Type = ParamType.Parameter
                     });
                 }
             }

--- a/src/Nightingale.Converters/Postman/PostmanConverter.cs
+++ b/src/Nightingale.Converters/Postman/PostmanConverter.cs
@@ -28,7 +28,8 @@ namespace Nightingale.Converters.Postman
             var collection = new Item
             {
                 Type = ItemType.Collection,
-                Name = postmanCollection.Info?.Name
+                Name = postmanCollection.Info?.Name,
+                Children = new List<Item>()
             };
 
             IList<Item> children = ConvertItems(postmanCollection.Items);
@@ -67,8 +68,18 @@ namespace Nightingale.Converters.Postman
                 }
                 else if (item.Items != null && item.Items.Length > 0)
                 {
-                    IList<Item> childCollections = ConvertItems(item.Items);
-                    list.AddRange(childCollections);
+                    Item nightingaleSubCollection = new Item
+                    {
+                        Type = ItemType.Collection,
+                        Children = new List<Item>(),
+                        Name = item.Name
+                    };
+                    IList<Item> nightingaleChildren = ConvertItems(item.Items);
+                    if (nightingaleChildren != null)
+                    {
+                        nightingaleSubCollection.Children.AddRange(nightingaleChildren);
+                    }
+                    list.Add(nightingaleSubCollection);
                 }
             }
 
@@ -219,7 +230,8 @@ namespace Nightingale.Converters.Postman
                 Type = ItemType.Request,
                 Url = new Url
                 {
-                    Base = postmanRequest.Url?.Raw
+                    Base = postmanRequest.Url?.Raw,
+                    Queries = new List<Parameter>()
                 },
                 Body = ConvertBody(postmanRequest.Body),
                 Method = postmanRequest.Method,

--- a/src/Nightingale.Core.sln
+++ b/src/Nightingale.Core.sln
@@ -7,7 +7,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Nightingale.Core", "Nightin
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Nightingale.Data", "Nightingale.Data\Nightingale.Data.csproj", "{01512EC6-BB7D-42FC-B4C3-0B9AF6375D8D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nightingale.Converters", "Nightingale.Converters\Nightingale.Converters.csproj", "{8B230AFD-02F2-4115-8B3E-284C86214738}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Nightingale.Converters", "Nightingale.Converters\Nightingale.Converters.csproj", "{8B230AFD-02F2-4115-8B3E-284C86214738}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nightingale.Test", "Nightingale.Test\Nightingale.Test.csproj", "{748E01BC-D7C5-40CD-AF09-CFA520E24898}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -27,6 +29,10 @@ Global
 		{8B230AFD-02F2-4115-8B3E-284C86214738}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8B230AFD-02F2-4115-8B3E-284C86214738}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8B230AFD-02F2-4115-8B3E-284C86214738}.Release|Any CPU.Build.0 = Release|Any CPU
+		{748E01BC-D7C5-40CD-AF09-CFA520E24898}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{748E01BC-D7C5-40CD-AF09-CFA520E24898}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{748E01BC-D7C5-40CD-AF09-CFA520E24898}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{748E01BC-D7C5-40CD-AF09-CFA520E24898}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Nightingale.Test/Nightingale.Test.csproj
+++ b/src/Nightingale.Test/Nightingale.Test.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="coverlet.collector" Version="1.2.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Nightingale.Converters\Nightingale.Converters.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Nightingale.Test/PostmanConverterTest.cs
+++ b/src/Nightingale.Test/PostmanConverterTest.cs
@@ -60,11 +60,11 @@ namespace Nightingale.Test
 				],
 				""protocolProfileBehavior"": { }
 			}";
-			var postmanCollections = JsonConvert.DeserializeObject<Collection>(folderJson);
-			var nightingaleResult = _postmanConverter.ConvertCollection(postmanCollections);
-			var firstNightingaleItem = nightingaleResult.Children.First();
-            Assert.True(firstNightingaleItem.Name == "Test folder");
-			Assert.True(firstNightingaleItem.Children.Count == 1);
+			var ptCollections = JsonConvert.DeserializeObject<Collection>(folderJson);
+			var ngResult = _postmanConverter.ConvertCollection(ptCollections);
+			var firstNgItem = ngResult.Children.First();
+            Assert.True(firstNgItem.Name == "Test folder");
+			Assert.True(firstNgItem.Children.Count == 1);
         }
 		[Fact]
 		public void QueryParameterIsTheSame()
@@ -105,20 +105,20 @@ namespace Nightingale.Test
 				],
 				""protocolProfileBehavior"": { }
 			}";
-			var postmanCollections = JsonConvert.DeserializeObject<Collection>(folderJson);
-			var nightingaleResult = _postmanConverter.ConvertCollection(postmanCollections);
-			var postmanRequest = postmanCollections.Items.First();
-			var nightangleRequest = nightingaleResult.Children.First();
-			Assert.True(nightangleRequest.Type == ItemType.Request);
-			var postmanQuery = postmanRequest.Request.Url.Query;
-			var nightangleQueries = nightangleRequest.Url.Queries;
-			Assert.True(nightangleQueries.Count == postmanQuery.Count());
-			var count = nightangleQueries.Count;
+			var ptCollections = JsonConvert.DeserializeObject<Collection>(folderJson);
+			var ngResult = _postmanConverter.ConvertCollection(ptCollections);
+			var ptRequest = ptCollections.Items.First();
+			var ngRequest = ngResult.Children.First();
+			Assert.True(ngRequest.Type == ItemType.Request);
+			var ptQuery = ptRequest.Request.Url.Query;
+			var ngQueries = ngRequest.Url.Queries;
+			Assert.True(ngQueries.Count == ptQuery.Count());
+			var count = ngQueries.Count;
 			for (var i = 0; i < count; ++i)
             {
-				Assert.Equal(ParamType.Parameter, nightangleQueries[i].Type);
-				Assert.Equal(postmanQuery.ElementAt(i).Key, nightangleQueries[i].Key);
-				Assert.Equal(postmanQuery.ElementAt(i).Value, nightangleQueries[i].Value);
+				Assert.Equal(ParamType.Parameter, ngQueries[i].Type);
+				Assert.Equal(ptQuery.ElementAt(i).Key, ngQueries[i].Key);
+				Assert.Equal(ptQuery.ElementAt(i).Value, ngQueries[i].Value);
             }
 		}
 	}

--- a/src/Nightingale.Test/PostmanConverterTest.cs
+++ b/src/Nightingale.Test/PostmanConverterTest.cs
@@ -1,3 +1,4 @@
+using JeniusApps.Nightingale.Data.Models;
 using Newtonsoft.Json;
 using Nightingale.Converters.Postman;
 using Postman.NET.Collections.Models;
@@ -65,5 +66,60 @@ namespace Nightingale.Test
             Assert.True(firstNightingaleItem.Name == "Test folder");
 			Assert.True(firstNightingaleItem.Children.Count == 1);
         }
-    }
+		[Fact]
+		public void QueryParameterIsTheSame()
+		{
+			var folderJson = @"{
+				""info"": {
+					""_postman_id"": ""d3232d7e-a773-4953-8b80-0b5aa3fd79a5"",
+					""name"": ""Test Collection"",
+					""schema"": ""https://schema.getpostman.com/json/collection/v2.1.0/collection.json""
+				},
+				""item"": [
+					{
+						""name"": ""Test request"",
+						""request"": {
+							""method"": ""GET"",
+							""header"": [],
+							""url"": {
+								""raw"": ""http://localhost:3001?param1=a&param2=b"",
+								""protocol"": ""http"",
+								""host"": [
+									""localhost""
+								],
+								""port"": ""3001"",
+								""query"": [
+									{
+										""key"": ""param1"",
+										""value"": ""a""
+									},
+									{
+										""key"": ""param2"",
+										""value"": ""b""
+									}
+								]
+							}
+						},
+						""response"": []
+					}
+				],
+				""protocolProfileBehavior"": { }
+			}";
+			var postmanCollections = JsonConvert.DeserializeObject<Collection>(folderJson);
+			var nightingaleResult = _postmanConverter.ConvertCollection(postmanCollections);
+			var postmanRequest = postmanCollections.Items.First();
+			var nightangleRequest = nightingaleResult.Children.First();
+			Assert.True(nightangleRequest.Type == ItemType.Request);
+			var postmanQuery = postmanRequest.Request.Url.Query;
+			var nightangleQueries = nightangleRequest.Url.Queries;
+			Assert.True(nightangleQueries.Count == postmanQuery.Count());
+			var count = nightangleQueries.Count;
+			for (var i = 0; i < count; ++i)
+            {
+				Assert.Equal(ParamType.Parameter, nightangleQueries[i].Type);
+				Assert.Equal(postmanQuery.ElementAt(i).Key, nightangleQueries[i].Key);
+				Assert.Equal(postmanQuery.ElementAt(i).Value, nightangleQueries[i].Value);
+            }
+		}
+	}
 }

--- a/src/Nightingale.Test/PostmanConverterTest.cs
+++ b/src/Nightingale.Test/PostmanConverterTest.cs
@@ -1,0 +1,69 @@
+using Newtonsoft.Json;
+using Nightingale.Converters.Postman;
+using Postman.NET.Collections.Models;
+using System;
+using System.Linq;
+using Xunit;
+
+namespace Nightingale.Test
+{
+    public class PostmanConverterTest
+    {
+		private PostmanConverter _postmanConverter;
+		public PostmanConverterTest()
+        {
+			_postmanConverter = new PostmanConverter();
+		}
+        [Fact]
+        public void FolderIsRetained()
+        {
+            var folderJson = @"{
+				""info"": {
+					""_postman_id"": ""d3232d7e-a773-4953-8b80-0b5aa3fd79a5"",
+					""name"": ""Test Collection"",
+					""schema"": ""https://schema.getpostman.com/json/collection/v2.1.0/collection.json""
+				},
+				""item"": [
+					{
+						""name"": ""Test folder"",
+						""item"": [
+							{
+								""name"": ""Test request"",
+								""request"": {
+									""method"": ""GET"",
+									""header"": [],
+									""url"": {
+										""raw"": ""http://localhost:3001?param1=a&param2=b"",
+										""protocol"": ""http"",
+										""host"": [
+											""localhost""
+										],
+										""port"": ""3001"",
+										""query"": [
+											{
+												""key"": ""param1"",
+												""value"": ""a""
+											},
+											{
+												""key"": ""param2"",
+												""value"": ""b""
+											}
+										]
+									}
+								},
+								""response"": []
+							}
+						],
+						""protocolProfileBehavior"": { }
+					}
+				],
+				""protocolProfileBehavior"": { }
+			}";
+			var postmanCollections = JsonConvert.DeserializeObject<Collection>(folderJson);
+			var nightingaleResult = _postmanConverter.ConvertCollection(postmanCollections);
+			var firstNightingaleItem = nightingaleResult.Children.First();
+            Assert.True(firstNightingaleItem.Name == "Test folder");
+			Assert.True(firstNightingaleItem.Children.Count == 1);
+        }
+    }
+}


### PR DESCRIPTION
**PR Description**
- Relevant to https://github.com/jenius-apps/nightingale-rest-api-client/issues/133
- Add test for `PostmanConverter`.
- Fix postman import not reserving folder.
- Fix query parameter's type was `Header`.

**Discussion**
1. I find myself losing track of whether a variable is referring to postman or nightingale collection/item, so I prepend `nightingale` and `postman` in front of `collection`/`item` where applicable. I'm used to shorthand so I could also write `pt` and `ng`. See if reviewers prefer the more verbose or shorter style.