### PR TITLE
add support for OData imports

### DIFF
--- a/src/Nightingale.Converters/Nightingale.Converters.csproj
+++ b/src/Nightingale.Converters/Nightingale.Converters.csproj
@@ -30,6 +30,7 @@
     <PackageReference Include="JeniusApps.Insomnia.NET" Version="0.0.3-preview" />
     <PackageReference Include="JeniusApps.Postman.NET" Version="0.2.4-preview" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageReference Include="Microsoft.OData.Core" Version="7.8.2" />
     <PackageReference Include="Microsoft.OpenApi" Version="1.2.3" />
     <PackageReference Include="MimeMapping" Version="1.0.1.30" />
   </ItemGroup>

--- a/src/Nightingale.Converters/OData/IODataConverter.cs
+++ b/src/Nightingale.Converters/OData/IODataConverter.cs
@@ -1,0 +1,28 @@
+﻿using JeniusApps.Nightingale.Data.Models;
+using Microsoft.OData.Edm;
+
+namespace JeniusApps.Nightingale.Converters.OData
+{
+    /// <summary>
+    /// Interface for converting a OData Metadata document into an <see cref="Item"/>
+    /// </summary>
+    public interface IODataConverter
+    {
+        /// <summary>
+        /// Converts a <see cref="IEdmModel"/>
+        /// into an <see cref="Item"/>.
+        /// </summary>
+        /// <param name="edmModel">The <see cref="IEdmModel"/> to convert.</param>
+        /// <returns>An <see cref="Item"/>.</returns>
+        Item? ConvertCollection(IEdmModel edmModel);
+
+        /// <summary>
+        /// Converts a <see cref="string"/> that contains a OData metadata xml
+        /// into an <see cref="Item"/>.
+        /// </summary>
+        /// <param name="edmModel">The <see cref="string"/> that is the 
+        /// OData metadata xml to convert.</param>
+        /// <returns>An <see cref="Item"/>.</returns>
+        Item? ConvertCollection(string edmModel);
+    }
+}

--- a/src/Nightingale.Converters/OData/ODataConverter.cs
+++ b/src/Nightingale.Converters/OData/ODataConverter.cs
@@ -1,0 +1,197 @@
+﻿using JeniusApps.Nightingale.Data.Models;
+using Microsoft.OData;
+using Microsoft.OData.Edm;
+using Microsoft.OData.Edm.Csdl;
+using Microsoft.OData.Edm.Validation;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Xml;
+
+namespace JeniusApps.Nightingale.Converters.OData
+{
+    /// <summary>
+    /// Class for converting a OData Metadata document to nightingale items
+    /// </summary>
+    public class ODataConverter : IODataConverter
+    {
+        /// <summary>
+        /// That's the placesholder for all urls.
+        /// </summary>
+        public const string NameOfPlaceHolder = "baseurl";
+
+        /// <inheritdoc/>
+        public Item? ConvertCollection(IEdmModel edmModel)
+        {
+            if (edmModel == null)
+            {
+                return null;
+            }
+            var collection = new Item
+            {
+                Type = ItemType.Collection,
+                Name = edmModel.EntityContainer.Name
+            };
+            collection.Children = GetAllEntities(edmModel.EntityContainer).ToList();
+            return collection;
+        }
+        /// <inheritdoc/>
+        public Item? ConvertCollection(string xml)
+        {
+            IEdmModel model;
+            IEnumerable<EdmError> errors = new List<EdmError>();
+            CsdlReader.TryParse(XmlReader.Create(new StringReader(xml)), out model, out errors);
+            if(errors.Count() != 0)
+            {
+                throw new ODataException($"Can't convert the given metadata document. " +
+                    $"There are {errors.Count()} erros in the document.");
+            }
+            return ConvertCollection(model);
+        }
+
+        private IEnumerable<Item> GetAllEntities(IEdmEntityContainer container)
+        {
+
+            foreach (var entity in container.Elements)
+            {
+                switch (entity.ContainerElementKind)
+                {
+                    case EdmContainerElementKind.EntitySet:
+                        yield return GetEntityUrls((IEdmEntitySet)entity);
+                        break;
+                    case EdmContainerElementKind.ActionImport:
+                        yield return GetActionUrls((IEdmActionImport)entity);
+                        break;
+                    case EdmContainerElementKind.FunctionImport:
+                        yield return GetFunctionUrls((IEdmFunctionImport)entity);
+                        break;
+                    case EdmContainerElementKind.Singleton:
+                        yield return GetSingeltoneUrls((IEdmSingleton)entity);
+                        break;
+                    default:
+                        throw new NotImplementedException($"The type '{entity.ContainerElementKind}' " +
+                            $"isn't implemented.");
+                }
+            }
+        }
+        private Item GetEntityUrls(IEdmEntitySet edmEntity)
+        {
+            var result = new Item
+            {
+                Type = ItemType.Collection,
+                Name = edmEntity.Name
+            };
+            result.Children = new List<Item>()
+            {
+                new Item()
+                {
+                    Name = "List",
+                    Type = ItemType.Request,
+                    Method = "GET",
+                    Url = new Url() { Base = $"{{{{{NameOfPlaceHolder}}}}}/{edmEntity.Name}" }
+                },
+                new Item(){
+                    Name = $"List full expanded",
+                    Type = ItemType.Request,
+                    Method = "GET",
+                    Url = new Url()
+                    {
+                        Base = $"{{{{{NameOfPlaceHolder}}}}}/{edmEntity.Name}",
+                        Queries = new List<Parameter>() {
+                                new Parameter() { Key = "$expand", Value = "*", Type = ParamType.Parameter }
+                            }
+                    }
+                },
+                new Item(){
+                    Name = $"Single",
+                    Type = ItemType.Request,
+                    Method = "GET",
+                    Url = new Url() { Base = $"{{{{{NameOfPlaceHolder}}}}}/{edmEntity.Name}/{{{{id}}}}" }
+                },
+                new Item(){
+                    Name = $"single full expanded",
+                    Type = ItemType.Request,
+                    Method = "GET",
+                    Url = new Url()
+                    {
+                        Base = $"{{{{{NameOfPlaceHolder}}}}}/{edmEntity.Name}/{{{{id}}}}",
+                        Queries = new List<Parameter>() {
+                                new Parameter() { Key = "$expand", Value = "*", Type = ParamType.Parameter }
+                        }
+                    }
+                }
+                // TODO: add support for bounded Actions
+            };
+            return result;
+            
+        }
+        private Item GetSingeltoneUrls(IEdmSingleton edmEntity)
+        {
+            var result = new Item
+            {
+                Type = ItemType.Collection,
+                Name = edmEntity.Name
+            };
+            result.Children = new List<Item>()
+            {  
+                new Item()
+                {
+                    Name = "single",
+                    Type = ItemType.Request,
+                    Method = "GET",
+                    Url = new Url() { Base = $"{{{{{NameOfPlaceHolder}}}}}/{edmEntity.Name}" }
+                },
+                new Item()
+                {
+                    Name = $"single full expanded",
+                    Type = ItemType.Request,
+                    Method = "GET",
+                    Url = new Url()
+                    {
+                        Base = $"{{{{{NameOfPlaceHolder}}}}}/{edmEntity.Name}",
+                        Queries = new List<Parameter>() {
+                                new Parameter() { Key = "$expand", Value = "*", Type = ParamType.Parameter }
+                            }
+                    }
+                }
+                // TODO: add support for bounded Actions
+            };
+            return result;
+        }
+        private Item GetFunctionUrls(IEdmFunctionImport edmEntity)
+        {
+            var functionParameters = string.Join(",", edmEntity.Function.Parameters.Select(d =>
+             {
+                 return $"{d.Name} = {{{{{d.Name}}}}}";
+             }));
+            return new Item()
+            {
+                Name = edmEntity.Name,
+                Type = ItemType.Request,
+                Method = "GET",
+                Url = new Url()
+                {
+                    Base = $"{{{{{NameOfPlaceHolder}}}}}/{edmEntity.Name}({functionParameters})"
+                }
+            };
+        }
+        private Item GetActionUrls(IEdmActionImport edmEntity)
+        {
+            var functionParameters = string.Join(",", edmEntity.Action.Parameters.Select(d =>
+            {
+                return $"{d.Name} = {{{{{d.Name}}}}}";
+            }));
+            return new Item()
+            {
+                Name = edmEntity.Name,
+                Type = ItemType.Request,
+                Method = "GET",
+                Url = new Url()
+                {
+                    Base = $"{{{{{NameOfPlaceHolder}}}}}/{edmEntity.Name}({functionParameters})"
+                }
+            };
+        }
+    }
+}

--- a/src/Nightingale.Converters/OData/ODataConverter.cs
+++ b/src/Nightingale.Converters/OData/ODataConverter.cs
@@ -161,6 +161,10 @@ namespace JeniusApps.Nightingale.Converters.OData
         }
         private Item GetFunctionUrls(IEdmFunctionImport edmEntity)
         {
+            if(edmEntity.Function.IsBound){
+                // currently we don't support bounded funcitons!
+                return null;
+            }
             var functionParameters = string.Join(",", edmEntity.Function.Parameters.Select(d =>
              {
                  return $"{d.Name} = {{{{{d.Name}}}}}";
@@ -178,6 +182,10 @@ namespace JeniusApps.Nightingale.Converters.OData
         }
         private Item GetActionUrls(IEdmActionImport edmEntity)
         {
+            if(edmEntity.Action.IsBound){
+                // currently we don't support bounded actions!
+                return null;
+            }
             var functionParameters = string.Join(",", edmEntity.Action.Parameters.Select(d =>
             {
                 return $"{d.Name} = {{{{{d.Name}}}}}";

--- a/src/Nightingale.Converters/OData/ODataConverter.cs
+++ b/src/Nightingale.Converters/OData/ODataConverter.cs
@@ -61,10 +61,18 @@ namespace JeniusApps.Nightingale.Converters.OData
                         yield return GetEntityUrls((IEdmEntitySet)entity);
                         break;
                     case EdmContainerElementKind.ActionImport:
-                        yield return GetActionUrls((IEdmActionImport)entity);
+                        var actionsResult = GetActionUrls((IEdmActionImport)entity);
+                        if(actionsResult == null){
+                            break;
+                        }
+                        yield return actionsResult;
                         break;
                     case EdmContainerElementKind.FunctionImport:
-                        yield return GetFunctionUrls((IEdmFunctionImport)entity);
+                        var functionsResult = GetFunctionUrls((IEdmFunctionImport)entity);
+                        if(functionsResult == null){
+                            break;
+                        }
+                        yield return functionsResult;
                         break;
                     case EdmContainerElementKind.Singleton:
                         yield return GetSingeltoneUrls((IEdmSingleton)entity);
@@ -159,7 +167,7 @@ namespace JeniusApps.Nightingale.Converters.OData
             };
             return result;
         }
-        private Item GetFunctionUrls(IEdmFunctionImport edmEntity)
+        private Item? GetFunctionUrls(IEdmFunctionImport edmEntity)
         {
             if(edmEntity.Function.IsBound){
                 // currently we don't support bounded funcitons!
@@ -180,7 +188,7 @@ namespace JeniusApps.Nightingale.Converters.OData
                 }
             };
         }
-        private Item GetActionUrls(IEdmActionImport edmEntity)
+        private Item? GetActionUrls(IEdmActionImport edmEntity)
         {
             if(edmEntity.Action.IsBound){
                 // currently we don't support bounded actions!

--- a/src/Nightingale.Test/ODataConverterTest.cs
+++ b/src/Nightingale.Test/ODataConverterTest.cs
@@ -1,0 +1,157 @@
+﻿using JeniusApps.Nightingale.Converters.OData;
+using JeniusApps.Nightingale.Data.Models;
+using Microsoft.OData;
+using Microsoft.OData.Edm;
+using Microsoft.OData.Edm.Csdl;
+using System.IO;
+using System.Linq;
+using System.Xml;
+using Xunit;
+
+namespace Nightingale.Test
+{
+    public class ODataConverterTest
+    {
+        private IEdmModel model;
+        private Item Item;
+        private ODataConverter converter;
+        public ODataConverterTest()
+        {
+            // This line gives us only the reference edmmodel.
+            // It isn't used in the converter.
+            CsdlReader.TryParse(XmlReader.Create(new StringReader(sampleMetadataDocument)), out model, out _);
+            converter = new ODataConverter();
+            Item = converter.ConvertCollection(sampleMetadataDocument);
+        }
+
+        [Fact]
+        public void TheEntityContainerNameMustMatchTheItemName()
+        {
+            Assert.Equal(model.EntityContainer.Name, Item.Name);
+        }
+
+        [Fact]
+        public void TheUrlMustHaveAPlaceHolderForBaseUrl()
+        {
+            var entityset =model.EntityContainer.Elements.First(d => d.ContainerElementKind == EdmContainerElementKind.EntitySet).Name;
+            Assert.Contains("{{" + ODataConverter.NameOfPlaceHolder + "}}/", Item.
+                Children.
+                First(d => d.Name == entityset).
+                    Children.
+                    First().Url.Base);
+        }
+
+        [Fact]
+        public void AllSingleEntityUrlsMustHaveAPlaceHolderForTheId()
+        {
+            var entityset = model.EntityContainer.Elements.First(d => d.ContainerElementKind == EdmContainerElementKind.EntitySet).Name;
+            Assert.Contains("{{id}}", Item.
+                Children.
+                First(d => d.Name == entityset).
+                    Children.
+                    First(r => r.Name == "Single").Url.Base);
+        }
+
+        [Fact]
+        public void ASingletonOnlyCreatesTwoRequests()
+        {
+            var singeltonEntity = model.EntityContainer.Elements.First(d => d.ContainerElementKind == EdmContainerElementKind.Singleton);
+
+            Assert.Single(Item.Children.Where(d => d.Name == singeltonEntity.Name));
+            Assert.Equal(2, Item.Children.First(d => d.Name == singeltonEntity.Name).Children.Count());
+        }
+
+        [Fact]
+        public void AEntityCreatesFourRequests()
+        {
+            var entity = model.EntityContainer.Elements.First(d => d.ContainerElementKind == EdmContainerElementKind.EntitySet);
+            Assert.Single(Item.Children.Where(d => d.Name == entity.Name));
+            Assert.Equal(4, Item.Children.First(d => d.Name == entity.Name).Children.Count());
+        }
+
+        [Fact]
+        public void ConvertingAWrongMetadataDocumentThrowsAnError()
+        {
+            Assert.Throws<ODataException>(() => converter.ConvertCollection("random string"));
+        }
+
+        /// <summary>
+        /// This is a OData metadocument sample
+        /// It was original written here: https://github.com/OData/AspNetCoreOData/blob/d324fc04bd291cdda061310f0e56ff7aefd3ac00/test/Microsoft.AspNetCore.OData.Tests/Formatter/Deserialization/ODataResourceDeserializerTests.cs#L1149
+        /// </summary>
+        private const string sampleMetadataDocument = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<edmx:Edmx Version=""4.0""
+    xmlns:edmx=""http://docs.oasis-open.org/odata/ns/edmx"">
+  <edmx:DataServices m:DataServiceVersion=""4.0"" m:MaxDataServiceVersion=""4.0""
+      xmlns:m=""http://docs.oasis-open.org/odata/ns/metadata"">
+    <Schema Namespace=""ODataDemo""
+        xmlns=""http://docs.oasis-open.org/odata/ns/edm"">
+      <EntityType Name=""Product"">
+        <Key>
+          <PropertyRef Name=""ID"" />
+        </Key>
+        <Property Name=""ID"" Type=""Edm.Int32"" Nullable=""false"" />
+        <Property Name=""Name"" Type=""Edm.String"" />
+        <Property Name=""Description"" Type=""Edm.String"" />
+        <Property Name=""ReleaseDate"" Type=""Edm.DateTimeOffset"" Nullable=""false"" />
+        <Property Name=""DiscontinuedDate"" Type=""Edm.DateTimeOffset"" />
+        <Property Name=""PublishDate"" Type=""Edm.Date"" />
+        <Property Name=""Rating"" Type=""Edm.Int32"" Nullable=""false"" />
+        <Property Name=""Price"" Type=""Edm.Decimal"" Nullable=""false"" />
+        <NavigationProperty Name=""Category"" Type=""ODataDemo.Category"" Partner=""Products"" />
+        <NavigationProperty Name=""Supplier"" Type=""ODataDemo.Supplier"" Partner=""Products"" />
+      </EntityType>
+      <EntityType Name=""Category"">
+        <Key>
+          <PropertyRef Name=""ID"" />
+        </Key>
+        <Property Name=""ID"" Type=""Edm.Int32"" Nullable=""false"" />
+        <Property Name=""Name"" Type=""Edm.String"" />
+        <NavigationProperty Name=""Products"" Type=""Collection(ODataDemo.Product)"" Partner=""Category"" />
+      </EntityType>
+      <EntityType Name=""Supplier"">
+        <Key>
+          <PropertyRef Name=""ID"" />
+        </Key>
+        <Property Name=""ID"" Type=""Edm.Int32"" Nullable=""false"" />
+        <Property Name=""Name"" Type=""Edm.String"" />
+        <Property Name=""Address"" Type=""ODataDemo.Address"" />
+        <Property Name=""Location"" Type=""Edm.GeographyPoint"" SRID=""Variable"" />
+        <Property Name=""Concurrency"" Type=""Edm.Int32"" Nullable=""false"" />
+        <NavigationProperty Name=""Products"" Type=""Collection(ODataDemo.Product)"" Partner=""Supplier"" />
+      </EntityType>
+      <ComplexType Name=""Address"">
+        <Property Name=""Street"" Type=""Edm.String"" />
+        <Property Name=""City"" Type=""Edm.String"" />
+        <Property Name=""State"" Type=""Edm.String"" />
+        <Property Name=""ZipCode"" Type=""Edm.String"" />
+        <Property Name=""CountryOrRegion"" Type=""Edm.String"" />
+      </ComplexType>
+      <Function Name=""GetProductsByRating"" m:HttpMethod=""GET"">
+        <ReturnType Type=""Collection(ODataDemo.Product)"" />
+        <Parameter Name=""rating"" Type=""Edm.Int32"" Nullable=""false"" />
+      </Function>
+      <EntityContainer Name=""DemoService"" m:IsDefaultEntityContainer=""true"">
+        <EntitySet Name=""Products"" EntityType=""ODataDemo.Product"">
+          <NavigationPropertyBinding Path=""Category"" Target=""Categories"" />
+          <NavigationPropertyBinding Path=""Supplier"" Target=""Suppliers"" />
+        </EntitySet>
+        <EntitySet Name=""Categories"" EntityType=""ODataDemo.Category"">
+          <NavigationPropertyBinding Path=""Products"" Target=""Products"" />
+        </EntitySet>
+        <Singleton Name=""Me"" Type=""ODataDemo.Supplier""/>
+        <EntitySet Name=""Suppliers"" EntityType=""ODataDemo.Supplier"">
+          <NavigationPropertyBinding Path=""Products"" Target=""Products"" />
+          <Annotation Term=""Org.OData.Core.V1.OptimisticConcurrency"">
+            <Collection>
+              <PropertyPath>Concurrency</PropertyPath>
+            </Collection>
+          </Annotation>
+        </EntitySet>
+        <FunctionImport Name=""GetProductsByRating"" Function=""ODataDemo.GetProductsByRating"" EntitySet=""Products"" IncludeInServiceDocument=""true"" />
+      </EntityContainer>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>";
+    }
+}


### PR DESCRIPTION
This will add support to use an OData Metadata document to create a collection for your OData endpoint. If you want to test it with a real service there is for example the Microsoft graph endpoint:

`https://graph.microsoft.com/v1.0/$metadata`

Is there some way for me to also extend the UI?
It would be cool if the UI is a mix of the `CURL` import and one of the others.
So you can copy-paste the metadata text or you can search for a file.
Maybe also a third option for an URL would be nice.

